### PR TITLE
[XMOFBasedModelLoader] Put everything in a single resource at load time

### DIFF
--- a/plugins/org.modelexecution.xmof.gemoc.engine/src/org/modelexecution/xmof/gemoc/engine/internal/XMOFBasedModelLoader.java
+++ b/plugins/org.modelexecution.xmof.gemoc.engine/src/org/modelexecution/xmof/gemoc/engine/internal/XMOFBasedModelLoader.java
@@ -128,10 +128,9 @@ public class XMOFBasedModelLoader {
 		Set<Resource> relatedModelResources = new HashSet<Resource>();
 		if (resource != null) {
 			Set<Resource> relatedResources = EMFResource.getRelatedResources(resource);
-			relatedResources.removeIf(r -> r.getContents().get(0) == resource.getContents().get(0));
+			relatedResources.removeIf(r -> r == null || r.getContents().get(0) == resource.getContents().get(0));
 			relatedModelResources.add(resource);
 			relatedModelResources.addAll(relatedResources);
-			relatedModelResources.removeIf(r -> r == null);
 		}
 		return relatedModelResources;
 	}
@@ -154,7 +153,8 @@ public class XMOFBasedModelLoader {
 					EObject referencedEObject = objectValue.getEObject();
 
 					if (referencedEObject != null) {
-						allRelatedResources.addAll(getRelatedResources(referencedEObject.eResource()));
+						Collection<Resource> relatedResources = getRelatedResources(referencedEObject.eResource());
+						allRelatedResources.addAll(relatedResources);
 					}
 				}
 			}
@@ -164,6 +164,13 @@ public class XMOFBasedModelLoader {
 				if (!executionContext.getResourceModel().getContents().contains(o))
 					parameterValueObjects.add(o);
 			});
+
+			// We put all other required resources in the executed model resource
+			// Eg. in fUML, the "executionenvironment"
+			for (EObject o : new HashSet<EObject>(r.getContents())) {
+				addWithTransaction(getModelResource().getContents(), o);
+			}
+
 		}
 
 		return parameterValueObjects;
@@ -260,7 +267,7 @@ public class XMOFBasedModelLoader {
 			}
 		}
 
-		// Hack: we add the same annotations as melange so all dynamic parts of/ the metamodel
+		// Hack: we add the same annotations as melange so all dynamic parts of the metamodel
 		for (EPackage p : confMMPackages) {
 			p.eAllContents().forEachRemaining((o) -> {
 				if (o instanceof EStructuralFeature || (o instanceof EClass && !(o instanceof Activity)
@@ -366,6 +373,11 @@ public class XMOFBasedModelLoader {
 	private EditingDomain getEditingDomain() {
 		ResourceSet resourceSet = getResourceSet();
 		return TransactionUtil.getEditingDomain(resourceSet);
+	}
+
+	private void addWithTransaction(EList<?> list, Object o) {
+		Command cmd = new AddCommand(getEditingDomain(), list, o);
+		getEditingDomain().getCommandStack().execute(cmd);
 	}
 
 }


### PR DESCRIPTION
When loading input parameters, move related resources contents in the
executed model resource, so that they can be observed (eg. for trace
construction)